### PR TITLE
bugs fix: ipset installation for all OS and tweaks for playbooks

### DIFF
--- a/demo/playbook/roles/bamboofw_agent/tasks/main.yaml
+++ b/demo/playbook/roles/bamboofw_agent/tasks/main.yaml
@@ -27,6 +27,11 @@
 
 - name: Default execution for all supported distribution
   block:
+    - name: Install pre-requisite packages for calico-felix agent
+      ansible.builtin.package:
+        name: ipset
+        state: present
+
     - name: Build hosts file
       lineinfile:
         path: /etc/hosts

--- a/demo/playbook/roles/bamboofw_agent/tasks/old-os-support.yml
+++ b/demo/playbook/roles/bamboofw_agent/tasks/old-os-support.yml
@@ -12,10 +12,8 @@
 - name: Install neccessary tools
   yum:
     name:
-    - vim
     - wget
     - yum-utils
-    - ipset
     state: present
     update_cache: yes
 
@@ -42,6 +40,7 @@
     get_url:
       url: "https://ftp.gnu.org/gnu/make/make-{{make_version}}.tar.gz"
       dest: "/tmp/make-{{make_version}}.tar.gz"
+      validate_certs: false
   - name: Extract archive
     unarchive:
       src: "/tmp/make-{{make_version}}.tar.gz"
@@ -80,6 +79,7 @@
     get_url:
       url: https://ftp.gnu.org/gnu/glibc/glibc-{{glibc_version}}.tar.gz
       dest: "/tmp/glibc-{{glibc_version}}.tar.gz"
+      validate_certs: false
   - name: Extract archive
     unarchive:
       src: "/tmp/glibc-{{glibc_version}}.tar.gz"

--- a/demo/playbook/roles/bamboofw_agent/tasks/pre-tasks.yml
+++ b/demo/playbook/roles/bamboofw_agent/tasks/pre-tasks.yml
@@ -22,8 +22,6 @@
         name:
         - wget
         - yum-utils
-        - ipset
-        - wget
         state: present
         update_cache: yes
       ignore_errors: True


### PR DESCRIPTION
- Move ipset installtion to ansible.builtin.package module. Now will be performed for all OS.
- Tweak playbook for CentOS/RedHat 7 or lower with "skip certificate check" when download make and glibc tar archives